### PR TITLE
Escape leading space in a text blurb with `\`

### DIFF
--- a/src/writerly.gleam
+++ b/src/writerly.gleam
@@ -246,19 +246,11 @@ fn parse_from_tentative(
 fn nonempty_suffix_diagnostic(suffix: String) -> NonemptySuffixDiagnostic {
   let assert False = suffix == ""
 
-  case string.starts_with(suffix, "|>") {
-    True -> Pipe(string.drop_start(suffix, 2))
-
-    False ->
-      case string.starts_with(suffix, "```") {
-        True -> TripleBacktick(string.drop_start(suffix, 3))
-
-        False ->
-          case string.starts_with(suffix, "\\") {
-            True -> BackwardSlash(string.drop_start(suffix, 1))
-            False -> Other(suffix)
-          }
-      }
+  case suffix {
+    "```" <> _ -> TripleBacktick(string.drop_start(suffix, 3))
+    "|>" <> _ -> Pipe(string.drop_start(suffix, 2))
+    "\\" <> _ -> BackwardSlash(string.drop_start(suffix, 1))
+    _ -> Other(suffix)
   }
 }
 

--- a/test/sample.emu
+++ b/test/sample.emu
@@ -4,16 +4,13 @@
 |> Root
     attr1=val1
 
-    \       I'm a text line with leading space
+    \   I'm a text line with leading space
 
 
     |> Child1
         attr1 = val1
 
-
         some text
-
-        \ Another line with LESS leading space
 
     |> Child2
 

--- a/test/sample.emu
+++ b/test/sample.emu
@@ -4,11 +4,16 @@
 |> Root
     attr1=val1
 
+    \       I'm a text line with leading space
+
+
     |> Child1
         attr1 = val1
 
 
         some text
+
+        \ Another line with LESS leading space
 
     |> Child2
 


### PR DESCRIPTION
Text blurb are indented by four spaces and cannot start with leading space. 

This PR introduces a **new text blurb** that can have leading space and the block is identified by `\` which escapes leading space in the rendered format.